### PR TITLE
Remove placeholder images from Email1 template

### DIFF
--- a/Email1.html
+++ b/Email1.html
@@ -117,7 +117,6 @@
 
                       <img src="Imgcolumn1.png" alt="Reemplazar con imagen logística" width="300">
 
-                      <img src="https://via.placeholder.com/600x400/2E1D72/FFFFFF?text=Imagen+1" alt="Reemplazar con imagen logística" width="300">
 
                     </td>
                     <td class="column text-block" width="50%" valign="top" style="padding:24px; font-size:16px;">
@@ -137,13 +136,11 @@
                     <td class="column" width="50%" valign="top" style="padding:0;">
                       <img src="Imgcolumn3.png" alt="Reemplazar con imagen de operaciones" width="300">
 
-                      <img src="https://via.placeholder.com/600x400/2E1D72/FFFFFF?text=Imagen+2" alt="Reemplazar con imagen de infraestructura" width="300">
                     </td>
                   </tr>
 
                   <tr>
                     <td class="column" width="50%" valign="top" style="padding:0;">
-                      <img src="https://via.placeholder.com/600x400/2E1D72/FFFFFF?text=Imagen+3" alt="Reemplazar con imagen de operaciones" width="300">
 
                     </td>
                     <td class="column text-block" width="50%" valign="top" style="padding:24px; font-size:16px;">


### PR DESCRIPTION
## Summary
- remove the temporary placeholder images from the Email1 template's feature columns

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dad612bfec8326a2a01c21f680c039