### PR TITLE
Use Pilat Wide font in email template

### DIFF
--- a/Email1.html
+++ b/Email1.html
@@ -42,9 +42,9 @@
       --dp-bg:#ffffff;
       --text:#202934;
     }
-    body,table,td{font-family:'Pilat','Space Grotesk',Arial,Helvetica,sans-serif;color:var(--text);line-height:1.5}
+    body,table,td{font-family:'Pilat Wide',Arial,Helvetica,sans-serif;color:var(--text);line-height:1.5}
 
-    h1{margin:0 0 12px;font-size:28px;line-height:1.2;color:#0b2239;text-transform:uppercase;font-family:'Pilat Wide','Pilat','Space Grotesk',Arial,Helvetica,sans-serif}
+    h1{margin:0 0 12px;font-size:28px;line-height:1.2;color:#0b2239;text-transform:uppercase;font-family:'Pilat Wide',Arial,Helvetica,sans-serif}
 
     h2{margin:0 0 8px;font-size:16px;letter-spacing:.5px;text-transform:uppercase;color:var(--dp-navy)}
     p{margin:0 0 16px;font-size:16px}


### PR DESCRIPTION
## Summary
- update the default font stack in Email1.html to rely on Pilat Wide for body text and headings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daf5367fe88326adc25a95783a4fcb