### PR TITLE
Inline DP World font faces for email templates

### DIFF
--- a/Email1.html
+++ b/Email1.html
@@ -9,23 +9,14 @@
   <!-- Fuente Space Grotesk -->
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&amp;display=swap" rel="stylesheet">
 
-  <!-- Preload DP World fonts -->
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/941d76a709888f84-s.p.woff2" as="font" type="font/woff2" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/aa0440b489ca5503-s.p.woff" as="font" type="font/woff" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/7fb5202acf443571-s.p.woff2" as="font" type="font/woff2" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/788aa5acf673b5ba-s.p.woff" as="font" type="font/woff" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/4f5a2518db58e266-s.p.woff2" as="font" type="font/woff2" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/4d1c4c86921e1c04-s.p.woff" as="font" type="font/woff" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/e8be59c28c61969a-s.p.woff2" as="font" type="font/woff2" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/bd85f7a801159798-s.p.woff" as="font" type="font/woff" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/f74f3351a83d4f5e-s.p.woff2" as="font" type="font/woff2" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/6e39ceeae5fd9f6e-s.p.woff" as="font" type="font/woff" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/717ee44606c04e97-s.p.woff2" as="font" type="font/woff2" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/0013e0ec058df89d-s.p.woff" as="font" type="font/woff" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/5e7985dc4ff21878-s.p.woff2" as="font" type="font/woff2" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/468c1b1c38b85b42-s.p.woff" as="font" type="font/woff" crossorigin="anonymous" data-next-font="size-adjust">
-
   <style>
+    @font-face{font-family:'Pilat';src:url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/4146efbdd93947d6b2acf537cc838a42?v=1de3d8be') format('woff2'),url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/721e9a821ef54c62b91eac1f5d2ae9fd?v=ccaa4732') format('woff');font-weight:300;font-style:normal;font-display:swap}
+    @font-face{font-family:'Pilat';src:url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/0d2b8db593024d11961ad765869196a6?v=4d9ce941') format('woff2'),url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/bb68c6ae36e64c2a9c31a88771cf5590?v=ca6ab305') format('woff');font-weight:400;font-style:normal;font-display:swap}
+    @font-face{font-family:'Pilat';src:url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/9466f8da380642219db7719df29fa70c?v=323929a5') format('woff2'),url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/a3a0df07c8bc4747ae06529ceaeba467?v=4a3f9adb') format('woff');font-weight:600;font-style:normal;font-display:swap}
+    @font-face{font-family:'Pilat Wide';src:url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/5c4ca10737cd4cf8ba80daec2c205a56?v=faca217c') format('woff2'),url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/58a8d47d612f43ef991d03cfc4e6bcfc?v=662c6bad') format('woff');font-weight:400;font-style:normal;font-display:swap}
+    @font-face{font-family:'Pilat Wide';src:url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/d3ca4a7bb8664eb2b8fb8724b3c1579f?v=f1b1c2cf') format('woff2'),url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/41d05fabcdde4c70b41b7c40a0e429c9?v=a5ef197d') format('woff');font-weight:600;font-style:normal;font-display:swap}
+    @font-face{font-family:'Pilat Wide';src:url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/303e1722b5604af78d100d69e36bc59e?v=33c0bc62') format('woff2'),url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/a1c1d6d6e1f54b67af53b6b790dbac5?v=bd5669c4') format('woff');font-weight:700;font-style:normal;font-display:swap}
+    @font-face{font-family:'Pilat Wide';src:url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/344d2b7aa8034347bbf0c4d08db2cc38?v=47e57f21') format('woff2'),url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/2d7d10b132f344baa8db80cf5c087e47?v=34720ef2') format('woff');font-weight:800;font-style:normal;font-display:swap}
     html,body{margin:0!important;padding:0!important;height:100%!important;width:100%!important}
     *{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
     table,td{mso-table-lspace:0pt!important;mso-table-rspace:0pt!important}
@@ -43,9 +34,9 @@
       --dp-bg:#ffffff;
       --text:#202934;
     }
-    body,table,td{font-family:'Pilat Wide',Arial,Helvetica,sans-serif;color:var(--text);line-height:1.5}
+    body,table,td{font-family:'Pilat Wide','Pilat','Space Grotesk',Arial,Helvetica,sans-serif;color:var(--text);line-height:1.5}
 
-    h1{margin:0 0 12px;font-size:28px;line-height:1.2;color:#0b2239;text-transform:uppercase;font-family:'Pilat Wide',Arial,Helvetica,sans-serif}
+    h1{margin:0 0 12px;font-size:28px;line-height:1.2;color:#0b2239;text-transform:uppercase;font-family:'Pilat Wide','Pilat','Space Grotesk',Arial,Helvetica,sans-serif}
 
     h2{margin:0 0 8px;font-size:16px;letter-spacing:.5px;text-transform:uppercase;color:var(--dp-navy)}
     p{margin:0 0 16px;font-size:16px}

--- a/Email2.html
+++ b/Email2.html
@@ -10,23 +10,14 @@
   <!-- Fuente Space Grotesk -->
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet">
 
-  <!-- Preload DP World fonts -->
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/941d76a709888f84-s.p.woff2" as="font" type="font/woff2" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/aa0440b489ca5503-s.p.woff" as="font" type="font/woff" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/7fb5202acf443571-s.p.woff2" as="font" type="font/woff2" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/788aa5acf673b5ba-s.p.woff" as="font" type="font/woff" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/4f5a2518db58e266-s.p.woff2" as="font" type="font/woff2" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/4d1c4c86921e1c04-s.p.woff" as="font" type="font/woff" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/e8be59c28c61969a-s.p.woff2" as="font" type="font/woff2" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/bd85f7a801159798-s.p.woff" as="font" type="font/woff" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/f74f3351a83d4f5e-s.p.woff2" as="font" type="font/woff2" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/6e39ceeae5fd9f6e-s.p.woff" as="font" type="font/woff" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/717ee44606c04e97-s.p.woff2" as="font" type="font/woff2" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/0013e0ec058df89d-s.p.woff" as="font" type="font/woff" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/5e7985dc4ff21878-s.p.woff2" as="font" type="font/woff2" crossorigin="anonymous" data-next-font="size-adjust">
-  <link rel="preload" href="https://www.dpworld.com/_next/static/media/468c1b1c38b85b42-s.p.woff" as="font" type="font/woff" crossorigin="anonymous" data-next-font="size-adjust">
-
   <style>
+    @font-face{font-family:'Pilat';src:url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/4146efbdd93947d6b2acf537cc838a42?v=1de3d8be') format('woff2'),url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/721e9a821ef54c62b91eac1f5d2ae9fd?v=ccaa4732') format('woff');font-weight:300;font-style:normal;font-display:swap}
+    @font-face{font-family:'Pilat';src:url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/0d2b8db593024d11961ad765869196a6?v=4d9ce941') format('woff2'),url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/bb68c6ae36e64c2a9c31a88771cf5590?v=ca6ab305') format('woff');font-weight:400;font-style:normal;font-display:swap}
+    @font-face{font-family:'Pilat';src:url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/9466f8da380642219db7719df29fa70c?v=323929a5') format('woff2'),url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/a3a0df07c8bc4747ae06529ceaeba467?v=4a3f9adb') format('woff');font-weight:600;font-style:normal;font-display:swap}
+    @font-face{font-family:'Pilat Wide';src:url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/5c4ca10737cd4cf8ba80daec2c205a56?v=faca217c') format('woff2'),url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/58a8d47d612f43ef991d03cfc4e6bcfc?v=662c6bad') format('woff');font-weight:400;font-style:normal;font-display:swap}
+    @font-face{font-family:'Pilat Wide';src:url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/d3ca4a7bb8664eb2b8fb8724b3c1579f?v=f1b1c2cf') format('woff2'),url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/41d05fabcdde4c70b41b7c40a0e429c9?v=a5ef197d') format('woff');font-weight:600;font-style:normal;font-display:swap}
+    @font-face{font-family:'Pilat Wide';src:url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/303e1722b5604af78d100d69e36bc59e?v=33c0bc62') format('woff2'),url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/a1c1d6d6e1f54b67af53b6b790dbac5?v=bd5669c4') format('woff');font-weight:700;font-style:normal;font-display:swap}
+    @font-face{font-family:'Pilat Wide';src:url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/344d2b7aa8034347bbf0c4d08db2cc38?v=47e57f21') format('woff2'),url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/2d7d10b132f344baa8db80cf5c087e47?v=34720ef2') format('woff');font-weight:800;font-style:normal;font-display:swap}
     html,body{margin:0!important;padding:0!important;height:100%!important;width:100%!important}
     *{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
     table,td{mso-table-lspace:0pt!important;mso-table-rspace:0pt!important}


### PR DESCRIPTION
## Summary
- replace font preload tags in both email templates with inline @font-face declarations for Pilat and Pilat Wide
- keep both woff2 and woff sources for each weight and refresh the font-family stacks to retain Pilat-based fallbacks

## Testing
- Viewed Email1.html in a local browser
- Viewed Email2.html in a local browser

------
https://chatgpt.com/codex/tasks/task_e_68dc385431908326a6c954187eb66540