### PR TITLE
Improve Gmail mobile font support

### DIFF
--- a/Email1.html
+++ b/Email1.html
@@ -6,10 +6,9 @@
   <title>República Dominicana: El punto donde todo se conecta. 🌍📦</title>
   <meta name="description" content="En el corazón del Caribe, opera un ecosistema logístico único para negocios que buscan crecer.">
 
-  <!-- Fuente Space Grotesk -->
-  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&amp;display=swap" rel="stylesheet">
-
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&display=swap');
+
     @font-face{font-family:'Pilat';src:url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/4146efbdd93947d6b2acf537cc838a42?v=1de3d8be') format('woff2'),url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/721e9a821ef54c62b91eac1f5d2ae9fd?v=ccaa4732') format('woff');font-weight:300;font-style:normal;font-display:swap}
     @font-face{font-family:'Pilat';src:url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/0d2b8db593024d11961ad765869196a6?v=4d9ce941') format('woff2'),url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/bb68c6ae36e64c2a9c31a88771cf5590?v=ca6ab305') format('woff');font-weight:400;font-style:normal;font-display:swap}
     @font-face{font-family:'Pilat';src:url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/9466f8da380642219db7719df29fa70c?v=323929a5') format('woff2'),url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/a3a0df07c8bc4747ae06529ceaeba467?v=4a3f9adb') format('woff');font-weight:600;font-style:normal;font-display:swap}
@@ -35,6 +34,8 @@
       --text:#202934;
     }
     body,table,td{font-family:'Pilat Wide','Pilat','Space Grotesk',Arial,Helvetica,sans-serif;color:var(--text);line-height:1.5}
+    .gmail-font{font-family:'Pilat Wide','Pilat','Space Grotesk',Arial,Helvetica,sans-serif}
+    u + .body .gmail-font, u + .body .gmail-font *{font-family:'Space Grotesk',Arial,Helvetica,sans-serif!important}
 
     h1{margin:0 0 12px;font-size:28px;line-height:1.2;color:#0b2239;text-transform:uppercase;font-family:'Pilat Wide','Pilat','Space Grotesk',Arial,Helvetica,sans-serif}
 
@@ -62,7 +63,7 @@
 
   </style>
 </head>
-<body class="wrap" style="margin:0; padding:0; width:100%; height:100%; background-color:#ffffff;">
+<body class="wrap body gmail-font" style="margin:0; padding:0; width:100%; height:100%; background-color:#ffffff;">
 
   <center role="article" aria-roledescription="email" lang="es">
 

--- a/Email2.html
+++ b/Email2.html
@@ -7,10 +7,9 @@
   <title>El ecosistema logístico ideal para establecer y hacer crecer tu empresa</title>
   <meta name="description" content="DP World Dominicana opera un ecosistema integrado para importar, exportar y distribuir con eficiencia, velocidad y trazabilidad.">
 
-  <!-- Fuente Space Grotesk -->
-  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet">
-
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&display=swap');
+
     @font-face{font-family:'Pilat';src:url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/4146efbdd93947d6b2acf537cc838a42?v=1de3d8be') format('woff2'),url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/721e9a821ef54c62b91eac1f5d2ae9fd?v=ccaa4732') format('woff');font-weight:300;font-style:normal;font-display:swap}
     @font-face{font-family:'Pilat';src:url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/0d2b8db593024d11961ad765869196a6?v=4d9ce941') format('woff2'),url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/bb68c6ae36e64c2a9c31a88771cf5590?v=ca6ab305') format('woff');font-weight:400;font-style:normal;font-display:swap}
     @font-face{font-family:'Pilat';src:url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/9466f8da380642219db7719df29fa70c?v=323929a5') format('woff2'),url('https://dpw-p-001.sitecorecontenthub.cloud/api/public/content/a3a0df07c8bc4747ae06529ceaeba467?v=4a3f9adb') format('woff');font-weight:600;font-style:normal;font-display:swap}
@@ -36,6 +35,8 @@
       --text:#202934;
     }
     body,table,td{font-family:'Pilat','Space Grotesk',Arial,Helvetica,sans-serif;color:var(--text);line-height:1.5}
+    .gmail-font{font-family:'Pilat','Space Grotesk',Arial,Helvetica,sans-serif}
+    u + .body .gmail-font, u + .body .gmail-font *{font-family:'Space Grotesk',Arial,Helvetica,sans-serif!important}
 
     h1{margin:0 0 12px;font-size:28px;line-height:1.2;color:#0b2239;text-transform:uppercase;font-family:'Pilat Wide','Pilat','Space Grotesk',Arial,Helvetica,sans-serif}
 
@@ -57,7 +58,7 @@
     }
   </style>
 </head>
-<body class="wrap" style="margin:0; padding:0; width:100%; height:100%; background-color:#ffffff;">
+<body class="wrap body gmail-font" style="margin:0; padding:0; width:100%; height:100%; background-color:#ffffff;">
 
   <center role="article" aria-roledescription="email" lang="es">
 


### PR DESCRIPTION
## Summary
- load the Space Grotesk font via CSS @import so Gmail mobile retains the typeface
- add Gmail-targeting font fallbacks and apply the helper class on the body element

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc3c44d6cc8326953c953f31df2cbe